### PR TITLE
feat: add support for enumerating all certificates COMPASS-4105

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,32 @@
 # macos-export-certificate-and-key
-Export a certificate and its corresponding private key from the macOS default keychain. This module is a native addon. It will only successfully work on macOS 10.12+. No prebuilt binaries are currently provided.
 
-This module returns a single certificate and its private key combination as a `.pfx` file, along with a random passphrase that has been used for encrypting the file. It will throw an exception if no relevant certificate could be found. The certificate in question can be specified either through its subject line string or its thumbprint.
+Access the macOS system certificate and key store.
+This module is a native addon. It will only successfully work on macOS 10.12+. No prebuilt binaries are currently provided.
+
+## API
+
+### `exportCertificateAndPrivateKey(opts?)`
+
+Export a certificate and its corresponding private key from the macOS CA store.
+
+Valid options are:
+
+- `subject`: Subject line of the certificate/key as a string.
+- `thumbprint`: Thumbprint of the certificate/key as a Uint8Array.
+  Either `subject` or `thumbprint` must be provided.
+
+This function returns a single certificate (and by default its private key)
+combination as a .pfx file, along with a random passphrase that has been
+used for encrypting the file.
+It will throw an exception if no relevant certificate could be found.
+The certificate in question can be specified either through its subject line
+string or its thumbprint.
 
 When exporting, the user will be prompted to enter his password to allow keychain access.
+
+### `exportSystemCertificates()`
+
+Export all system certificates (no private keys).
 
 ## Testing
 You need to import [`testkeys\certificate.pfx`](./testkeys/certificate.pfx) manually into your local keychain in order for the tests to pass. The password for the file is `pass`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,22 @@
-declare function exportCertificateAndPrivateKey(input: {
+declare type LookupOptions = {
   subject: string;
+  thumbprint?: never;
 } | {
+  subject?: never;
   thumbprint: Uint8Array;
-}): { passphrase: string; pfx: Uint8Array; };
+};
+
+declare interface PfxResult {
+  passphrase: string;
+  pfx: Uint8Array;
+};
+
+declare function exportCertificateAndPrivateKey(input: LookupOptions): PfxResult;
+
+declare namespace exportCertificateAndPrivateKey {
+  function exportCertificateAndPrivateKey(input: LookupOptions): PfxResult;
+
+  function exportSystemCertificates(input: StoreOptions): string[];
+}
+
 export = exportCertificateAndPrivateKey;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-const { exportCertificate } = require('bindings')('macos_export_certificate_and_key');
+const { exportCertificateAndKey, exportAllCertificates } = require('bindings')('macos_export_certificate_and_key');
 const { randomBytes } = require('crypto');
 const util = require('util');
 
-module.exports = function exportCertificateAndPrivateKey({
+function exportCertificateAndPrivateKey({
     subject,
     thumbprint
 }) {
@@ -20,9 +20,13 @@ module.exports = function exportCertificateAndPrivateKey({
   }
 
   const passphrase = randomBytes(12).toString('hex');
-  const pfx = exportCertificate(
+  const pfx = exportCertificateAndKey(
     subject ? { subject } : { thumbprint },
     passphrase
   );
   return { passphrase, pfx };
 };
+
+module.exports = exportCertificateAndPrivateKey;
+module.exports.exportCertificateAndPrivateKey = exportCertificateAndPrivateKey;
+module.exports.exportSystemCertificates = exportAllCertificates;


### PR DESCRIPTION
(sibling PR to https://github.com/mongodb-js/win-export-certificate-and-key/pull/2)

##### feat: add support for enumerating all certificates COMPASS-4105

This is conceptually very similar to the functionality
exposed by https://github.com/jfromaniello/mac-ca, but this
variant doesn't require spawning external commands.

Since this package already accesses the macOS system
CA stores, it feels like a natural place to add this here.

##### chore: clean up native implementation

Prefer C++-style left-leaning pointers, C++-style casts over their
C equivalents, and align braces style with our other native addons
and our JS code.