### PR TITLE
chore: fix compilation pre-C++17

### DIFF
--- a/src/certs.cc
+++ b/src/certs.cc
@@ -53,7 +53,7 @@ void failOnError(OSStatus status, const char* error) {
           CFStringGetLength(str.get()),
 	        kCFStringEncodingUTF8) +
       1);
-    CFStringGetCString(str.get(), &msg.data()[offset], msg.size() - offset, kCFStringEncodingUTF8);
+    CFStringGetCString(str.get(), &msg[offset], msg.size() - offset, kCFStringEncodingUTF8);
     msg.resize(strlen(msg.data()));
     throw std::runtime_error(msg);
   }


### PR DESCRIPTION
`.data()` returns `const char*` rather than `char*` before C++17. It's also not needed in this particular case.

Example failure in https://github.com/mongodb-js/mongosh/pull/2206: https://parsley.mongodb.com/evergreen/mongosh_darwin_unit_test_m60xc_n16_cli_repl_patch_e78998f6c73b2aefa47cecd09860ff23c49d1971_6720d3bc72739c000719b6c9_24_10_29_12_23_25/0/task?bookmarks=0%2C11393&selectedLineRange=L4981&shareLine=4981